### PR TITLE
enable cross

### DIFF
--- a/server.js
+++ b/server.js
@@ -52,6 +52,13 @@ app.use(bodyParser.json({
 }));
 //API DOC
 app.use('/doc', express.static(path.join(__dirname, './apidoc')));
+
+//Enable cross
+app.use(function(req, res, next) {
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+    next();
+})
 routes(app);
 
 app.listen(port);


### PR DESCRIPTION
this modification allows to authorize cros, in order to correct the error 'cors not allow' in the angular side.